### PR TITLE
Move URL generation for routing to Routing

### DIFF
--- a/assets/elm/FileUpload/Update.elm
+++ b/assets/elm/FileUpload/Update.elm
@@ -1,6 +1,6 @@
 module FileUpload.Update exposing (update, subscriptions)
 
-import Navigation exposing (newUrl)
+import Routing exposing (Route(Terms), navigateTo)
 import FileUpload.Models exposing (Upload, File, UploadProgress(..), Loaded(..), Total(..), UploadFailure(..), Token(..), jsonFileToFile)
 import FileUpload.Messages exposing (Msg(..))
 import FileUpload.Ports exposing (..)
@@ -50,7 +50,7 @@ update msg upload =
 
         FileUploadSuccess token ->
             ( { upload | progress = Succeeded (Token token) }
-            , tokenCmd token
+            , navigateTo <| Terms token
             )
 
         EmptyErrors ->
@@ -68,11 +68,6 @@ errBody =
 contains some errors.  Try to verify the file with a
 [CSV checker](https://csvlint.io/). Also make sure that your encoding
 is UTF-8."""
-
-
-tokenCmd : String -> Cmd Msg
-tokenCmd token =
-    newUrl <| "/#terms/" ++ token
 
 
 parseFailureType : String -> UploadFailure

--- a/assets/elm/Routing.elm
+++ b/assets/elm/Routing.elm
@@ -1,6 +1,6 @@
-module Routing exposing (..)
+module Routing exposing (Token, Route(..), navigateTo, parseLocation)
 
-import Navigation exposing (Location)
+import Navigation exposing (Location, newUrl)
 import UrlParser exposing (..)
 
 
@@ -16,6 +16,40 @@ type Route
     | NotFoundRoute
 
 
+navigateTo : Route -> Cmd a
+navigateTo =
+    newUrl << urlFor
+
+
+urlFor : Route -> String
+urlFor r =
+    case r of
+        FileUpload ->
+            "/"
+
+        Terms token ->
+            "/#terms/" ++ token
+
+        Target token ->
+            "/#target/" ++ token
+
+        Resolver token ->
+            "/#resolver/" ++ token
+
+        NotFoundRoute ->
+            "/#404"
+
+
+parseLocation : Location -> Route
+parseLocation location =
+    case parseHash matchers location of
+        Just route ->
+            route
+
+        Nothing ->
+            NotFoundRoute
+
+
 matchers : Parser (Route -> a) a
 matchers =
     oneOf
@@ -24,13 +58,3 @@ matchers =
         , map Target (s "target" </> string)
         , map Resolver (s "resolver" </> string)
         ]
-
-
-parseLocation : Location -> Route
-parseLocation location =
-    case (parseHash matchers location) of
-        Just route ->
-            route
-
-        Nothing ->
-            NotFoundRoute

--- a/assets/elm/Target/Update.elm
+++ b/assets/elm/Target/Update.elm
@@ -1,6 +1,6 @@
 module Target.Update exposing (update)
 
-import Navigation exposing (newUrl)
+import Routing exposing (Route(Resolver), navigateTo)
 import Json.Encode as Encode
 import Http
 import Helper as H
@@ -22,7 +22,7 @@ update msg ds =
             ( ds, Cmd.none )
 
         ToResolver token ->
-            ( ds, newUrl <| "/#resolver/" ++ token )
+            ( ds, navigateTo <| Resolver token )
 
         CurrentTarget token current ->
             ( { ds | current = current }, saveTarget token current )

--- a/assets/elm/Terms/Update.elm
+++ b/assets/elm/Terms/Update.elm
@@ -1,6 +1,6 @@
 module Terms.Update exposing (update)
 
-import Navigation exposing (newUrl)
+import Routing exposing (Route(Target, Resolver), navigateTo)
 import Maybe exposing (withDefault)
 import Http
 import Helper as H
@@ -23,10 +23,10 @@ update msg terms =
                 ( { terms | headers = headers }, saveTerms token termsList )
 
         ToDataSources token ->
-            ( terms, newUrl <| "/#target/" ++ token )
+            ( terms, navigateTo <| Target token )
 
         ToResolver token ->
-            ( terms, newUrl <| "/#resolver/" ++ token )
+            ( terms, navigateTo <| Resolver token )
 
         GetTerms (Ok newTerms) ->
             ( newTerms, Cmd.none )


### PR DESCRIPTION
What?
=====

This moves URL generation for routes to the `Routing` module, ensuring all
logic for route generation and parsing is captured within a single file.