### PR TITLE
Fix #38 xlsx extension substitution

### DIFF
--- a/lib/gnlr/excel_builder.rb
+++ b/lib/gnlr/excel_builder.rb
@@ -6,7 +6,7 @@ module Gnlr
     def initialize(output_path)
       @file = File.split(output_path).last
       @file_path = output_path
-      @excel_path = output_path.gsub(/csv$/, "xlsx")
+      @excel_path = excel_path(output_path)
     end
 
     def build
@@ -21,6 +21,10 @@ module Gnlr
     end
 
     private
+
+    def excel_path(path)
+      path.gsub(File.extname(path), ".xlsx")
+    end
 
     def insert_rows(sheet)
       CSV.open(@file_path, col_sep: "\t").each do |l|


### PR DESCRIPTION
Before only .csv extension was substituted correctly with .xlsx
extension. However we do not control what kind of extension people
use for their csv file. Any extension should work now.