### PR TITLE
Make all routes "refreshable"

### DIFF
--- a/src/elm/Data/Token.elm
+++ b/src/elm/Data/Token.elm
@@ -1,0 +1,28 @@
+module Data.Token
+    exposing
+        ( Token
+        , toString
+        , fromString
+        , encode
+        )
+
+import Json.Encode
+
+
+type Token
+    = Token String
+
+
+toString : Token -> String
+toString (Token token) =
+    token
+
+
+fromString : String -> Token
+fromString =
+    Token
+
+
+encode : Token -> Json.Encode.Value
+encode =
+    Json.Encode.string << toString

--- a/src/elm/FileUpload/Messages.elm
+++ b/src/elm/FileUpload/Messages.elm
@@ -1,6 +1,7 @@
 module FileUpload.Messages exposing (Msg(..))
 
 import FileUpload.Models exposing (JsonFile)
+import Data.Token exposing (Token)
 
 
 type Msg
@@ -13,4 +14,4 @@ type Msg
     | FileUploadStarted ()
     | FileUploadComplete ()
     | FileUploadFailed String
-    | FileUploadSuccess String
+    | FileUploadSuccess Token

--- a/src/elm/FileUpload/Models.elm
+++ b/src/elm/FileUpload/Models.elm
@@ -1,6 +1,7 @@
 module FileUpload.Models exposing (..)
 
 import Errors exposing (Errors)
+import Data.Token exposing (Token)
 
 
 type Loaded
@@ -9,10 +10,6 @@ type Loaded
 
 type Total
     = Total Float
-
-
-type Token
-    = Token String
 
 
 type Bytes
@@ -77,16 +74,6 @@ progressToCompletionPercent progress =
     case progress of
         Loading (Loaded loaded) (Total total) ->
             Just <| round <| (loaded / total) * 100
-
-        _ ->
-            Nothing
-
-
-uploadToken : Upload -> Maybe String
-uploadToken upload =
-    case upload.progress of
-        Succeeded (Token token) ->
-            Just token
 
         _ ->
             Nothing

--- a/src/elm/FileUpload/Update.elm
+++ b/src/elm/FileUpload/Update.elm
@@ -1,9 +1,10 @@
 module FileUpload.Update exposing (update, subscriptions)
 
 import Routing exposing (Route(Terms), navigateTo)
-import FileUpload.Models exposing (Upload, UploadProgress(..), Loaded(..), Total(..), UploadFailure(..), Token(..), jsonFileToFile)
+import FileUpload.Models exposing (Upload, UploadProgress(..), Loaded(..), Total(..), UploadFailure(..), jsonFileToFile)
 import FileUpload.Messages exposing (Msg(..))
 import FileUpload.Ports exposing (..)
+import Data.Token as Token
 
 
 subscriptions : Sub Msg
@@ -15,7 +16,7 @@ subscriptions =
         , fileUploadStarted FileUploadStarted
         , fileUploadComplete FileUploadComplete
         , fileUploadFailed FileUploadFailed
-        , fileUploadSuccess FileUploadSuccess
+        , fileUploadSuccess (FileUploadSuccess << Token.fromString)
         ]
 
 
@@ -49,7 +50,7 @@ update msg upload =
             )
 
         FileUploadSuccess token ->
-            ( { upload | progress = Succeeded (Token token) }
+            ( { upload | progress = Succeeded token }
             , navigateTo <| Terms token
             )
 

--- a/src/elm/FileUpload/View.elm
+++ b/src/elm/FileUpload/View.elm
@@ -21,8 +21,9 @@ import Json.Decode as JD
 import Material.Progress as Loading
 import View.Layout exposing (contentWrapper, buttonStyles)
 import I18n exposing (Translation(..))
-import FileUpload.Models exposing (Upload, File, Token(..), Bytes(..), UploadProgress(..), progressToCompletionPercent)
+import FileUpload.Models exposing (Upload, File, Bytes(..), UploadProgress(..), progressToCompletionPercent)
 import FileUpload.Messages exposing (Msg(..))
+import Data.Token exposing (Token)
 
 
 view : Upload -> Html Msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1,22 +1,11 @@
 module Main exposing (..)
 
 import Subscriptions exposing (subscriptions)
-import Models exposing (Model, Flags, initModel)
+import Models exposing (Model, Flags)
 import Messages exposing (Msg(..))
-import Update exposing (update)
+import Update exposing (init, update)
 import View exposing (view)
 import Navigation exposing (Location)
-import Routing exposing (Route)
-import FileUpload.Ports as FUP
-
-
-init : Flags -> Location -> ( Model, Cmd Msg )
-init flags location =
-    let
-        currentRoute =
-            Routing.parseLocation location
-    in
-        ( initModel flags currentRoute, FUP.isUploadSupported () )
 
 
 main : Program Flags Model Msg

--- a/src/elm/Models.elm
+++ b/src/elm/Models.elm
@@ -13,7 +13,6 @@ type alias Model =
     { route : Routing.Route
     , resolverUrl : String
     , localDomain : String
-    , token : Maybe String
     , upload : Upload
     , terms : Terms
     , target : Target
@@ -37,7 +36,6 @@ initModel flags route =
     Model route
         flags.resolverUrl
         flags.localDomain
-        Nothing
         initUpload
         initTerms
         (initTarget flags.dataSourcesIds)

--- a/src/elm/Models.elm
+++ b/src/elm/Models.elm
@@ -7,6 +7,7 @@ import Terms.Models exposing (Terms, initTerms)
 import Target.Models exposing (Target, initTarget)
 import Resolver.Models exposing (Resolver, initResolver)
 import Errors exposing (Errors)
+import Data.Token exposing (Token)
 
 
 type alias Model =
@@ -45,7 +46,7 @@ initModel flags route =
         Material.model
 
 
-currentToken : Model -> Maybe String
+currentToken : Model -> Maybe Token
 currentToken { route } =
     case route of
         FileUpload ->

--- a/src/elm/Resolver/Api.elm
+++ b/src/elm/Resolver/Api.elm
@@ -11,29 +11,30 @@ import Json.Decode exposing (null)
 import Resolver.Messages exposing (Msg(..))
 import Resolver.Encoder as RE
 import Resolver.Decoder exposing (statsAndErrorsDecoder)
+import Data.Token as Token exposing (Token)
 
 
-queryResolutionProgress : String -> Cmd Msg
+queryResolutionProgress : Token -> Cmd Msg
 queryResolutionProgress token =
     let
         url =
-            "/stats/" ++ token
+            "/stats/" ++ Token.toString token
     in
         Http.send ResolutionProgress
             (Http.get url statsAndErrorsDecoder)
 
 
-startResolution : String -> Cmd Msg
+startResolution : Token -> Cmd Msg
 startResolution token =
     let
         url =
-            "/resolver/" ++ token
+            "/resolver/" ++ Token.toString token
     in
         Http.send LaunchResolution
             (Http.get url (null ()))
 
 
-sendStopResolution : String -> Cmd Msg
+sendStopResolution : Token -> Cmd Msg
 sendStopResolution token =
     let
         url =

--- a/src/elm/Resolver/Decoder.elm
+++ b/src/elm/Resolver/Decoder.elm
@@ -9,7 +9,20 @@ import TimeDuration.Model exposing (..)
 
 statsAndErrorsDecoder : Decoder ( Stats, Errors )
 statsAndErrorsDecoder =
+    oneOf
+        [ notStartedDecoder
+        , existingStatsAndErrorsDecoder
+        ]
+
+
+existingStatsAndErrorsDecoder : Decoder ( Stats, Errors )
+existingStatsAndErrorsDecoder =
     map2 (,) statsDecoder errors
+
+
+notStartedDecoder : Decoder ( Stats, Errors )
+notStartedDecoder =
+    null ( NotStarted, Nothing )
 
 
 statsDecoder : Decoder Stats

--- a/src/elm/Resolver/Encoder.elm
+++ b/src/elm/Resolver/Encoder.elm
@@ -2,12 +2,13 @@ module Resolver.Encoder exposing (body)
 
 import Json.Encode exposing (..)
 import Http
+import Data.Token as Token exposing (Token)
 
 
-body : String -> Http.Body
+body : Token -> Http.Body
 body token =
     Http.jsonBody <|
         object
-            [ ( "token", string token )
+            [ ( "token", Token.encode token )
             , ( "stop_trigger", bool True )
             ]

--- a/src/elm/Resolver/Helper.elm
+++ b/src/elm/Resolver/Helper.elm
@@ -137,6 +137,9 @@ ingestionResolverProgress { stats } =
         NoStatsReceived ->
             Pending
 
+        NotStarted ->
+            Pending
+
         PendingResolution _ ->
             Pending
 
@@ -160,6 +163,9 @@ resolutionResolverProgress { stats } =
             Pending
 
         NoStatsReceived ->
+            Pending
+
+        NotStarted ->
             Pending
 
         PendingResolution _ ->

--- a/src/elm/Resolver/Models.elm
+++ b/src/elm/Resolver/Models.elm
@@ -51,6 +51,9 @@ metadataFromStats stats =
         NoStatsReceived ->
             Nothing
 
+        NotStarted ->
+            Nothing
+
         PendingResolution m ->
             Just m
 
@@ -69,6 +72,7 @@ metadataFromStats stats =
 
 type Stats
     = Unknown
+    | NotStarted
     | NoStatsReceived
     | PendingResolution ProgressMetadata
     | Ingesting ProgressMetadata Ingestion

--- a/src/elm/Resolver/Update.elm
+++ b/src/elm/Resolver/Update.elm
@@ -4,6 +4,7 @@ import Time exposing (millisecond)
 import Resolver.Models exposing (..)
 import Resolver.Messages exposing (Msg(..))
 import Resolver.Api exposing (queryResolutionProgress, sendStopResolution)
+import Data.Token exposing (Token)
 
 
 subscriptions : Resolver -> Sub Msg
@@ -16,7 +17,7 @@ subscriptions { stats } =
             Time.every (millisecond * 1000) QueryResolutionProgress
 
 
-update : Msg -> Resolver -> String -> ( Resolver, Cmd Msg )
+update : Msg -> Resolver -> Token -> ( Resolver, Cmd Msg )
 update msg resolver token =
     case msg of
         LaunchResolution (Ok _) ->

--- a/src/elm/Resolver/Update.elm
+++ b/src/elm/Resolver/Update.elm
@@ -3,7 +3,7 @@ module Resolver.Update exposing (subscriptions, update)
 import Time exposing (millisecond)
 import Resolver.Models exposing (..)
 import Resolver.Messages exposing (Msg(..))
-import Resolver.Api exposing (queryResolutionProgress, sendStopResolution)
+import Resolver.Api exposing (queryResolutionProgress, startResolution, sendStopResolution)
 import Data.Token exposing (Token)
 
 
@@ -34,7 +34,7 @@ update msg resolver token =
                 | stats = stats
                 , errors = errors
               }
-            , Cmd.none
+            , resolutionProgressCmd token stats
             )
 
         ResolutionProgress (Err _) ->
@@ -51,3 +51,13 @@ update msg resolver token =
 
         EmptyErrors ->
             ( { resolver | errors = Nothing }, Cmd.none )
+
+
+resolutionProgressCmd : Token -> Stats -> Cmd Msg
+resolutionProgressCmd token stats =
+    case stats of
+        NotStarted ->
+            startResolution token
+
+        _ ->
+            Cmd.none

--- a/src/elm/Routing.elm
+++ b/src/elm/Routing.elm
@@ -1,11 +1,8 @@
-module Routing exposing (Token, Route(..), navigateTo, parseLocation)
+module Routing exposing (Route(..), navigateTo, parseLocation)
 
 import Navigation exposing (Location, newUrl)
 import UrlParser exposing (..)
-
-
-type alias Token =
-    String
+import Data.Token as Token exposing (Token)
 
 
 type Route
@@ -28,13 +25,13 @@ urlFor r =
             "/"
 
         Terms token ->
-            "/#terms/" ++ token
+            "/#terms/" ++ Token.toString token
 
         Target token ->
-            "/#target/" ++ token
+            "/#target/" ++ Token.toString token
 
         Resolver token ->
-            "/#resolver/" ++ token
+            "/#resolver/" ++ Token.toString token
 
         NotFoundRoute ->
             "/#404"
@@ -54,7 +51,7 @@ matchers : Parser (Route -> a) a
 matchers =
     oneOf
         [ map FileUpload top
-        , map Terms (s "terms" </> string)
-        , map Target (s "target" </> string)
-        , map Resolver (s "resolver" </> string)
+        , map (Terms << Token.fromString) (s "terms" </> string)
+        , map (Target << Token.fromString) (s "target" </> string)
+        , map (Resolver << Token.fromString) (s "resolver" </> string)
         ]

--- a/src/elm/Target/Encoder.elm
+++ b/src/elm/Target/Encoder.elm
@@ -2,12 +2,13 @@ module Target.Encoder exposing (body)
 
 import Json.Encode exposing (..)
 import Http
+import Data.Token as Token exposing (Token)
 
 
-body : String -> Int -> Http.Body
+body : Token -> Int -> Http.Body
 body token targetId =
     Http.jsonBody <|
         object
-            [ ( "token", string token )
+            [ ( "token", Token.encode token )
             , ( "data_source_id", int targetId )
             ]

--- a/src/elm/Target/Messages.elm
+++ b/src/elm/Target/Messages.elm
@@ -2,11 +2,12 @@ module Target.Messages exposing (Msg(..))
 
 import Http
 import Target.Models exposing (DataSources)
+import Data.Token exposing (Token)
 
 
 type Msg
-    = CurrentTarget String Int
+    = CurrentTarget Token Int
     | SaveTarget (Result Http.Error ())
     | AllDataSources (Result Http.Error DataSources)
-    | ToResolver String
+    | ToResolver Token
     | FilterTarget String

--- a/src/elm/Target/Update.elm
+++ b/src/elm/Target/Update.elm
@@ -7,6 +7,7 @@ import Target.Models exposing (Target)
 import Target.Messages exposing (Msg(..))
 import Target.Helper as HDS
 import Target.Encoder as TE
+import Data.Token as Token exposing (Token)
 
 
 update : Msg -> Target -> ( Target, Cmd Msg )
@@ -36,7 +37,7 @@ update msg ds =
             ( { ds | filter = f }, Cmd.none )
 
 
-saveTarget : String -> Int -> Cmd Msg
+saveTarget : Token -> Int -> Cmd Msg
 saveTarget token targetId =
     let
         url =

--- a/src/elm/Target/View.elm
+++ b/src/elm/Target/View.elm
@@ -18,9 +18,10 @@ import I18n exposing (Translation(..))
 import View.Layout exposing (contentWrapper, styledButton)
 import Target.Models exposing (Target, DataSource)
 import Target.Messages exposing (Msg(..))
+import Data.Token exposing (Token)
 
 
-view : Target -> String -> Html Msg
+view : Target -> Token -> Html Msg
 view target token =
     contentWrapper BreadcrumbPickReferenceData
         PickReferenceDataDescription
@@ -43,7 +44,7 @@ view target token =
         ]
 
 
-continueButton : String -> Html Msg
+continueButton : Token -> Html Msg
 continueButton token =
     styledButton [] (ToResolver token) Continue
 
@@ -58,7 +59,7 @@ onInput msg =
     on "input" <| J.andThen (\t -> J.succeed <| msg (normalize t)) targetValue
 
 
-selectTarget : Target -> String -> Html Msg
+selectTarget : Target -> Token -> Html Msg
 selectTarget target token =
     let
         match t =
@@ -80,7 +81,7 @@ selectTarget target token =
             |> div []
 
 
-dataSourceRender : String -> Int -> DataSource -> Html Msg
+dataSourceRender : Token -> Int -> DataSource -> Html Msg
 dataSourceRender token current dsi =
     div []
         [ input

--- a/src/elm/Terms/Encoder.elm
+++ b/src/elm/Terms/Encoder.elm
@@ -2,17 +2,18 @@ module Terms.Encoder exposing (body)
 
 import Json.Encode exposing (..)
 import Http
+import Data.Token as Token exposing (Token)
 
 
-body : String -> List String -> Http.Body
+body : Token -> List String -> Http.Body
 body token terms =
     Http.jsonBody <|
         object
-            [ ( "token", string token )
+            [ ( "token", Token.encode token )
             , ( "alt_headers", termsEncoder terms )
             ]
 
 
 termsEncoder : List String -> Value
-termsEncoder terms =
-    list <| List.map (\t -> string t) terms
+termsEncoder =
+    list << List.map string

--- a/src/elm/Terms/Helper.elm
+++ b/src/elm/Terms/Helper.elm
@@ -3,13 +3,14 @@ module Terms.Helper exposing (getTerms)
 import Http
 import Terms.Messages exposing (Msg(..))
 import Terms.Decoder exposing (termsDecoder)
+import Data.Token as Token exposing (Token)
 
 
-getTerms : String -> Cmd Msg
+getTerms : Token -> Cmd Msg
 getTerms token =
     let
         url =
-            "/list_matchers/" ++ token
+            "/list_matchers/" ++ Token.toString token
     in
         Http.send GetTerms
             (Http.get url termsDecoder)

--- a/src/elm/Terms/Messages.elm
+++ b/src/elm/Terms/Messages.elm
@@ -2,11 +2,12 @@ module Terms.Messages exposing (Msg(..))
 
 import Http
 import Terms.Models exposing (Terms)
+import Data.Token exposing (Token)
 
 
 type Msg
-    = ToDataSources String
-    | ToResolver String
-    | MapTerm String Int String
+    = ToDataSources Token
+    | ToResolver Token
+    | MapTerm Token Int String
     | GetTerms (Result Http.Error Terms)
     | SaveTerms (Result Http.Error ())

--- a/src/elm/Terms/Update.elm
+++ b/src/elm/Terms/Update.elm
@@ -8,6 +8,7 @@ import Terms.Messages exposing (Msg(..))
 import Terms.Models exposing (Terms, Term, Header)
 import Terms.Decoder exposing (workflow, normalize)
 import Terms.Encoder as TE
+import Data.Token as Token exposing (Token)
 
 
 update : Msg -> Terms -> ( Terms, Cmd Msg )
@@ -103,7 +104,7 @@ prepareTerm term =
         Just term
 
 
-saveTerms : String -> List String -> Cmd Msg
+saveTerms : Token -> List String -> Cmd Msg
 saveTerms token terms =
     let
         url =

--- a/src/elm/Terms/View.elm
+++ b/src/elm/Terms/View.elm
@@ -11,9 +11,10 @@ import View.Layout exposing (contentWrapper, styledButton)
 import I18n exposing (Translation(..))
 import Terms.Messages exposing (Msg(..))
 import Target.Models exposing (DataSources)
+import Data.Token exposing (Token)
 
 
-view : DataSources -> Terms -> String -> Html Msg
+view : DataSources -> Terms -> Token -> Html Msg
 view ds terms token =
     contentWrapper BreadcrumbMapHeaders
         MapDescription
@@ -25,7 +26,7 @@ view ds terms token =
         ]
 
 
-continueButton : DataSources -> String -> Html Msg
+continueButton : DataSources -> Token -> Html Msg
 continueButton ds token =
     styledButton [] (nextMsg ds token) Continue
 
@@ -45,7 +46,7 @@ viewRowEntry re =
     Table.td [] [ text <| Maybe.withDefault "" re ]
 
 
-materialTable : String -> Terms -> Html Msg
+materialTable : Token -> Terms -> Html Msg
 materialTable token terms =
     div [ class "terms__table" ]
         [ Table.table []
@@ -55,7 +56,7 @@ materialTable token terms =
         ]
 
 
-nextMsg : DataSources -> String -> Msg
+nextMsg : DataSources -> Token -> Msg
 nextMsg ds token =
     if List.length ds > 1 then
         ToDataSources token
@@ -63,12 +64,12 @@ nextMsg ds token =
         ToResolver token
 
 
-viewSelectors : String -> Terms -> Html Msg
+viewSelectors : Token -> Terms -> Html Msg
 viewSelectors token terms =
     Table.tr [] (List.map (viewSelector token terms) terms.headers)
 
 
-viewSelector : String -> Terms -> Header -> Html Msg
+viewSelector : Token -> Terms -> Header -> Html Msg
 viewSelector token terms header =
     Table.th []
         [ text <| I18n.t TermMatchWithHeader

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -16,6 +16,7 @@ import Target.Helper as DSH
 import Resolver.Messages as RM
 import Resolver.Update as RU
 import Resolver.Api as RA
+import Data.Token as Token
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -107,7 +108,7 @@ updateResolver : RM.Msg -> Model -> ( Model, Cmd Msg )
 updateResolver msg model =
     let
         token =
-            Maybe.withDefault "" <| currentToken model
+            Maybe.withDefault (Token.fromString "") <| currentToken model
 
         ( resolverModel, resolverCmd ) =
             RU.update msg model.resolver token

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -12,6 +12,7 @@ import Terms.View as Terms
 import Target.View as Target
 import Target.Helper as Target
 import Resolver.View as Resolver
+import Data.Token exposing (Token)
 
 
 view : Model -> Html Msg
@@ -48,13 +49,13 @@ fileUploadView model =
     Html.map FileUploadMsg <| FileUpload.view model.upload
 
 
-termsView : Model -> Routing.Token -> Html Msg
+termsView : Model -> Token -> Html Msg
 termsView model token =
     Html.map TermsMsg <|
         Terms.view model.target.all model.terms token
 
 
-dataSourceView : Model -> Routing.Token -> Html Msg
+dataSourceView : Model -> Token -> Html Msg
 dataSourceView model token =
     Html.map TargetMsg <|
         Target.view model.target token


### PR DESCRIPTION
What?
=====

This updates routing to fire off any side-effects when the initial model is
loaded and we've parsed the URL, so any data necessary for the page is loaded
appropriately.

This doesn't allow for navigating forwards and backwards yet, however; there's
an issue currently with "refreshing" resolution after a new target is selected
that will need to be handled for that to work correctly. However, this improves
existing functionality and lays the foundation for additional extension.

This is a step towards resolution of #56.